### PR TITLE
Refactor some code

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -236,20 +236,19 @@ fn main() {
     SUBSCRIPTION_ID.store(subscription_id, Ordering::SeqCst);
     PUBLICATION_ID.store(publication_id, Ordering::SeqCst);
 
-    let mut pong_subscription = aeron.find_subscription(subscription_id);
-    while pong_subscription.is_err() {
-        std::thread::yield_now();
-        pong_subscription = aeron.find_subscription(subscription_id);
-    }
+    let pong_subscription = loop {
+        match aeron.find_subscription(subscription_id) {
+            Ok(p) => break p,
+            Err(_) => std::thread::yield_now(),
+        }
+    };
 
-    let mut ping_publication = aeron.find_publication(publication_id);
-    while ping_publication.is_err() {
-        std::thread::yield_now();
-        ping_publication = aeron.find_publication(publication_id);
-    }
-
-    let ping_publication = ping_publication.unwrap();
-    let pong_subscription = pong_subscription.unwrap();
+    let ping_publication = loop {
+        match aeron.find_publication(publication_id) {
+            Ok(p) => break p,
+            Err(_) => std::thread::yield_now(),
+        }
+    };
 
     //while COUNT_DOWN.load(Ordering::SeqCst) > 0 {
     //    std::thread::yield_now();

--- a/src/buffer_builder.rs
+++ b/src/buffer_builder.rs
@@ -110,15 +110,15 @@ impl BufferBuilder {
         loop {
             let new_capacity = capacity + (capacity >> 1);
 
-            if new_capacity < capacity || new_capacity > BUFFER_BUILDER_MAX_CAPACITY {
+            capacity = if new_capacity < capacity || new_capacity > BUFFER_BUILDER_MAX_CAPACITY {
                 if capacity == BUFFER_BUILDER_MAX_CAPACITY {
                     return Err(IllegalStateError::MaxCapacityReached(BUFFER_BUILDER_MAX_CAPACITY).into());
                 }
 
-                capacity = BUFFER_BUILDER_MAX_CAPACITY;
+                BUFFER_BUILDER_MAX_CAPACITY
             } else {
-                capacity = new_capacity;
-            }
+                new_capacity
+            };
 
             if capacity >= required_capacity {
                 break;
@@ -137,7 +137,7 @@ impl BufferBuilder {
             let new_buffer = alloc_buffer_aligned(new_capacity);
 
             unsafe {
-                std::ptr::copy(self.buffer, new_buffer, self.limit as usize);
+                std::ptr::copy_nonoverlapping(self.buffer, new_buffer, self.limit as usize);
                 dealloc_buffer_aligned(self.buffer, self.capacity)
             }
 

--- a/src/channel_uri.rs
+++ b/src/channel_uri.rs
@@ -102,20 +102,12 @@ impl ChannelUri {
 
     #[inline]
     pub fn get(&self, key: &str) -> &str {
-        if let Some(value) = self.params.get(key) {
-            value
-        } else {
-            ""
-        }
+        self.params.get(key).map(String::as_str).unwrap_or_default()
     }
 
     #[inline]
     pub fn get_or_default<'a>(&'a self, key: &str, default_value: &'a str) -> &'a str {
-        if let Some(value) = self.params.get(key) {
-            value
-        } else {
-            default_value
-        }
+        self.params.get(key).map(String::as_str).unwrap_or(default_value)
     }
 
     #[inline]
@@ -125,11 +117,7 @@ impl ChannelUri {
 
     #[inline]
     pub fn remove(&mut self, key: &str) -> String {
-        if let Some(result) = self.params.remove(key) {
-            result
-        } else {
-            String::default()
-        }
+        self.params.remove(key).unwrap_or_default()
     }
 
     #[inline]
@@ -138,21 +126,16 @@ impl ChannelUri {
     }
 
     pub fn parse(uri: &str) -> Result<Arc<Mutex<Self>>, AeronError> {
-        let mut position = 0;
-        let prefix;
-
-        if uri.starts_with(SPY_PREFIX) {
-            prefix = SPY_QUALIFIER;
-            position = SPY_PREFIX.len();
-        } else {
-            prefix = "";
-        }
-
-        if !&uri[position..].starts_with(AERON_PREFIX) {
-            return Err(IllegalArgumentError::UriMustStartWithAeron { uri: uri.to_string() }.into());
-        } else {
-            position += AERON_PREFIX.len();
-        }
+        let orig_uri = uri;
+        let (uri, prefix) = orig_uri
+            .strip_prefix(SPY_PREFIX)
+            .map(|u| (u, SPY_QUALIFIER))
+            .unwrap_or((orig_uri, ""));
+        let uri = uri
+            .strip_prefix(AERON_PREFIX)
+            .ok_or_else(|| IllegalArgumentError::UriMustStartWithAeron {
+                uri: orig_uri.to_string(),
+            })?;
 
         let mut builder = String::new();
         let mut params: HashMap<String, String> = HashMap::new();
@@ -160,20 +143,18 @@ impl ChannelUri {
         let mut key = String::new();
         let mut state = State::Media;
 
-        for i in position..uri.len() {
-            let c: char = uri.chars().nth(i).unwrap();
+        for (index, c) in uri.chars().enumerate() {
             match state {
                 State::Media => match c {
                     '?' => {
-                        media = builder.clone();
-                        builder.clear();
+                        media = std::mem::replace(&mut builder, String::new());
                         state = State::ParamsKey;
                     }
                     '=' | '|' | ':' => {
                         return Err(IllegalStateError::EncounteredCharacterWithinMediaDefinition {
                             c,
-                            index: i,
-                            uri: uri.to_string(),
+                            index,
+                            uri: orig_uri.to_string(),
                         }
                         .into());
                     }
@@ -183,19 +164,18 @@ impl ChannelUri {
                     if c == '=' {
                         if builder.is_empty() {
                             return Err(IllegalStateError::EmptyKeyNotAllowed {
-                                index: i,
-                                uri: uri.to_string(),
+                                index,
+                                uri: orig_uri.to_string(),
                             }
                             .into());
                         }
-                        key = builder.clone();
-                        builder.clear();
+                        key = std::mem::replace(&mut builder, String::new());
                         state = State::ParamsValue;
                     } else {
                         if c == '|' {
                             return Err(IllegalStateError::InvalidEndOfKey {
-                                index: i,
-                                uri: uri.to_string(),
+                                index,
+                                uri: orig_uri.to_string(),
                             }
                             .into());
                         }
@@ -204,8 +184,7 @@ impl ChannelUri {
                 }
                 State::ParamsValue => {
                     if c == '|' {
-                        params.insert(key.clone(), builder.clone());
-                        builder.clear();
+                        params.insert(key.clone(), std::mem::replace(&mut builder, String::new()));
                         state = State::ParamsKey;
                     } else {
                         builder.push(c);
@@ -245,11 +224,8 @@ impl ChannelUri {
 impl Display for ChannelUri {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut sb = String::new();
-        if self.prefix.is_empty() {
-            sb.reserve((self.params.len() * 20) + 10);
-        } else {
-            sb.reserve((self.params.len() * 20) + 20);
+        let mut sb = String::with_capacity(self.params.len() * 20 + 10 + 10 * self.prefix.is_empty() as usize);
+        if !self.prefix.is_empty() {
             sb += &self.prefix;
             if !self.prefix.ends_with(':') {
                 sb += ":";

--- a/src/command/control_protocol_events.rs
+++ b/src/command/control_protocol_events.rs
@@ -49,7 +49,7 @@ pub enum AeronCommand {
     ResponseOnClientTimeout = 0xF0A,
 
     #[cfg(test)]
-    UnitTestMessageTypeID = 0x65,
+    UnitTestMessageTypeId = 0x65,
 }
 
 impl AeronCommand {
@@ -84,7 +84,7 @@ impl AeronCommand {
             0xF0A => Self::ResponseOnClientTimeout,
 
             #[cfg(test)]
-            0x65 => Self::UnitTestMessageTypeID,
+            0x65 => Self::UnitTestMessageTypeId,
             _ => unreachable!("Unexpected control protocol event: {:x}", command_id),
         }
     }

--- a/src/concurrent/ring_buffer.rs
+++ b/src/concurrent/ring_buffer.rs
@@ -500,7 +500,7 @@ mod tests {
         let size = test.ring_buffer.max_msg_len() + 1;
         let write_res = test
             .ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, size);
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, size);
 
         assert_eq!(write_res.unwrap_err(), RingBufferError::MessageTooLong { msg: 129, max: 128 });
     }
@@ -516,7 +516,7 @@ mod tests {
         let aligned_record_length: Index = align(expected_record_length, record_descriptor::ALIGNMENT);
 
         test.ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, length)
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, length)
             .unwrap();
 
         let record_length = test.ab.get::<i32>(record_descriptor::length_offset(tail_index));
@@ -543,7 +543,7 @@ mod tests {
 
         let err = test
             .ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, length)
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, length)
             .unwrap_err();
         assert_eq!(err, RingBufferError::InsufficientCapacity);
         assert_eq!(test.ab.get::<i64>(TAIL_COUNTER_INDEX), tail as i64);
@@ -563,7 +563,7 @@ mod tests {
 
         let err = test
             .ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, length)
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, length)
             .unwrap_err();
         assert_eq!(err, RingBufferError::InsufficientCapacity);
         assert_eq!(test.ab.get::<i64>(TAIL_COUNTER_INDEX), tail as i64);
@@ -584,7 +584,7 @@ mod tests {
         test.ab.put::<i64>(TAIL_COUNTER_INDEX, tail as i64);
 
         test.ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, length)
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, length)
             .unwrap();
 
         assert_eq!(
@@ -619,7 +619,7 @@ mod tests {
         test.ab.put::<i64>(TAIL_COUNTER_INDEX, tail as i64);
 
         test.ring_buffer
-            .write(AeronCommand::UnitTestMessageTypeID, test.src_ab, 0, length)
+            .write(AeronCommand::UnitTestMessageTypeId, test.src_ab, 0, length)
             .unwrap();
 
         assert_eq!(
@@ -1003,7 +1003,7 @@ mod tests {
                 for i in 0..NUM_MESSAGES_PER_PUBLISHER {
                     src_ab.put::<i32>(message_num_offset, i as i32);
                     while ring_buffer
-                        .write(AeronCommand::UnitTestMessageTypeID, src_ab, 0, message_length)
+                        .write(AeronCommand::UnitTestMessageTypeId, src_ab, 0, message_length)
                         .is_err()
                     {
                         std::thread::yield_now();
@@ -1019,7 +1019,7 @@ mod tests {
             let message_number = buffer.get::<i32>(4);
 
             assert_eq!(buffer.capacity(), 4 + 4);
-            assert_eq!(command, AeronCommand::UnitTestMessageTypeID);
+            assert_eq!(command, AeronCommand::UnitTestMessageTypeId);
 
             let mut counts = COUNTS.lock().unwrap();
             assert_eq!(counts[id], message_number);

--- a/src/exclusive_publication.rs
+++ b/src/exclusive_publication.rs
@@ -563,7 +563,7 @@ impl ExclusivePublication {
             if position < limit {
                 let resulting_offset =
                     term_appender.claim(self.term_id, self.term_offset, &self.header_writer, length, &mut buffer_claim);
-                Ok(self.new_position(resulting_offset)?)
+                self.new_position(resulting_offset)
             } else {
                 Err(self.back_pressure_status(position, length))
             }

--- a/src/image.rs
+++ b/src/image.rs
@@ -47,24 +47,24 @@ pub enum ControlledPollAction {
     /**
      * Abort the current polling operation and do not advance the position for this fragment.
      */
-    ABORT = 1,
+    Abort = 1,
 
     /**
      * Break from the current polling operation and commit the position as of the end of the current fragment
      * being handled.
      */
-    BREAK,
+    Break,
 
     /**
      * Continue processing but commit the position as of the end of the current fragment so that
      * flow control is applied to this point.
      */
-    COMMIT,
+    Commit,
 
     /**
      * Continue processing taking the same approach as the in fragment_handler_t.
      */
-    CONTINUE,
+    Continue,
 }
 
 /**
@@ -119,11 +119,10 @@ impl Image {
             log_buffers.atomic_buffer(0).capacity(),
         );
 
-        let mut term_buffers: Vec<AtomicBuffer> = Vec::new();
-
-        for i in 0..log_buffer_descriptor::PARTITION_COUNT {
-            term_buffers.push(log_buffers.atomic_buffer(i))
-        }
+        // let mut term_buffers: Vec<AtomicBuffer> = Vec::new();
+        let term_buffers = (0..log_buffer_descriptor::PARTITION_COUNT)
+            .map(|i| log_buffers.atomic_buffer(i))
+            .collect::<Vec<_>>();
 
         let capacity = term_buffers[0].capacity();
 
@@ -133,7 +132,7 @@ impl Image {
         Self {
             term_buffers,
             header,
-            subscriber_position: (*subscriber_position).clone(),
+            subscriber_position: subscriber_position.clone(),
             log_buffers,
             source_identity,
             is_closed: Arc::new(AtomicBool::new(false)),
@@ -476,16 +475,16 @@ impl Image {
                 //     self.exception_handler(err)
                 // }
 
-                if ControlledPollAction::ABORT == action {
+                if ControlledPollAction::Abort == action {
                     resulting_offset -= aligned_length;
                     break;
                 }
 
                 fragments_read += 1;
 
-                if ControlledPollAction::BREAK == action {
+                if ControlledPollAction::Break == action {
                     break;
-                } else if ControlledPollAction::COMMIT == action {
+                } else if ControlledPollAction::Commit == action {
                     initial_position += (resulting_offset - initial_offset) as i64;
                     initial_offset = resulting_offset;
                     self.subscriber_position.set_ordered(initial_position);
@@ -560,16 +559,16 @@ impl Image {
                 )
                 .unwrap(); //todo
 
-                if ControlledPollAction::ABORT == action {
+                if ControlledPollAction::Abort == action {
                     resulting_offset -= aligned_length;
                     break;
                 }
 
                 fragments_read += 1;
 
-                if ControlledPollAction::BREAK == action {
+                if ControlledPollAction::Break == action {
                     break;
-                } else if ControlledPollAction::COMMIT == action {
+                } else if ControlledPollAction::Commit == action {
                     initial_position += (resulting_offset - initial_offset) as i64;
                     initial_offset = resulting_offset;
                     self.subscriber_position.set_ordered(initial_position);
@@ -651,7 +650,7 @@ impl Image {
                 )
                 .unwrap(); //todo
 
-                if ControlledPollAction::ABORT == action {
+                if ControlledPollAction::Abort == action {
                     break;
                 }
 
@@ -662,7 +661,7 @@ impl Image {
                     resulting_position = position;
                 }
 
-                if ControlledPollAction::BREAK == action {
+                if ControlledPollAction::Break == action {
                     break;
                 }
             }
@@ -802,7 +801,7 @@ mod tests {
         _length: Index,
         _header: &Header,
     ) -> Result<ControlledPollAction, AeronError> {
-        Ok(ControlledPollAction::CONTINUE)
+        Ok(ControlledPollAction::Continue)
     }
 
     #[allow(clippy::unnecessary_wraps)]
@@ -812,7 +811,7 @@ mod tests {
         _length: Index,
         _header: &Header,
     ) -> Result<ControlledPollAction, AeronError> {
-        Ok(ControlledPollAction::ABORT)
+        Ok(ControlledPollAction::Abort)
     }
 
     #[allow(clippy::unnecessary_wraps)]
@@ -822,7 +821,7 @@ mod tests {
         _length: Index,
         _header: &Header,
     ) -> Result<ControlledPollAction, AeronError> {
-        Ok(ControlledPollAction::BREAK)
+        Ok(ControlledPollAction::Break)
     }
 
     #[allow(clippy::unnecessary_wraps)]
@@ -833,9 +832,9 @@ mod tests {
         _header: &Header,
     ) -> Result<ControlledPollAction, AeronError> {
         if offset == data_frame_header::LENGTH {
-            return Ok(ControlledPollAction::COMMIT);
+            return Ok(ControlledPollAction::Commit);
         } else if offset == *ALIGNED_FRAME_LENGTH + data_frame_header::LENGTH {
-            return Ok(ControlledPollAction::ABORT);
+            return Ok(ControlledPollAction::Abort);
         }
 
         unreachable!("Should not get there!");
@@ -849,7 +848,7 @@ mod tests {
         _header: &Header,
     ) -> Result<ControlledPollAction, AeronError> {
         if offset == data_frame_header::LENGTH || offset == *ALIGNED_FRAME_LENGTH + data_frame_header::LENGTH {
-            return Ok(ControlledPollAction::CONTINUE);
+            return Ok(ControlledPollAction::Continue);
         }
 
         unreachable!("Should not get there!");

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -109,14 +109,11 @@ impl Subscription {
             return Err(IllegalStateError::SubscriptionClosed.into());
         }
 
-        if let Ok(endpoint_channel_cstr) = CString::new(endpoint_channel) {
-            self.conductor
-                .lock()
-                .expect("Mutex poisoned")
-                .add_rcv_destination(self.registration_id, endpoint_channel_cstr)
-        } else {
-            Err(GenericError::StringToCStringConversionFailed.into())
-        }
+        let endpoint_channel_cstr = CString::new(endpoint_channel).map_err(|_| GenericError::StringToCStringConversionFailed)?;
+        self.conductor
+            .lock()
+            .expect("Mutex poisoned")
+            .add_rcv_destination(self.registration_id, endpoint_channel_cstr)
     }
 
     pub fn remove_destination(&self, endpoint_channel: String) -> Result<i64, AeronError> {
@@ -124,14 +121,11 @@ impl Subscription {
             return Err(IllegalStateError::SubscriptionClosed.into());
         }
 
-        if let Ok(endpoint_channel_cstr) = CString::new(endpoint_channel) {
-            self.conductor
-                .lock()
-                .expect("Mutex poisoned")
-                .remove_rcv_destination(self.registration_id, endpoint_channel_cstr)
-        } else {
-            Err(GenericError::StringToCStringConversionFailed.into())
-        }
+        let endpoint_channel_cstr = CString::new(endpoint_channel).map_err(|_| GenericError::StringToCStringConversionFailed)?;
+        self.conductor
+            .lock()
+            .expect("Mutex poisoned")
+            .remove_rcv_destination(self.registration_id, endpoint_channel_cstr)
     }
 
     pub fn find_destination_response(&self, correlation_id: i64) -> Result<bool, AeronError> {
@@ -161,18 +155,47 @@ impl Subscription {
      */
 
     pub fn poll_end_of_streams(&self, end_of_stream_handler: EndOfStreamHandler) -> i32 {
-        let mut num_end_of_streams = 0;
+        self.image_list
+            .load()
+            .iter()
+            .filter(|i| i.is_end_of_stream())
+            .inspect(|i| end_of_stream_handler(i))
+            .count() as _
+    }
 
-        let image_list = self.image_list.load();
+    fn poll_inner(&mut self, fragment_limit: i32, mut poll_kind: impl FnMut(&mut Image, i32) -> i32) -> i32 {
+        let image_list = self.image_list.load_mut();
 
-        for image in image_list.iter() {
-            if image.is_end_of_stream() {
-                num_end_of_streams += 1;
-                end_of_stream_handler(image);
+        let starting_index = self.round_robin_index as usize;
+        self.round_robin_index += 1;
+
+        let starting_index = if starting_index >= image_list.len() {
+            self.round_robin_index = 0;
+            0
+        } else {
+            starting_index
+        };
+
+        let mut fragments_read = 0;
+        for i in starting_index..image_list.len() {
+            if fragments_read < fragment_limit {
+                fragments_read += poll_kind(
+                    image_list.get_mut(i).expect("Error getting element from Image vec"),
+                    fragments_read - fragment_limit,
+                );
             }
         }
 
-        num_end_of_streams
+        for i in 0..starting_index {
+            if fragments_read < fragment_limit {
+                fragments_read += poll_kind(
+                    image_list.get_mut(i).expect("Error getting element from Image vec"),
+                    fragments_read - fragment_limit,
+                );
+            }
+        }
+
+        fragments_read
     }
 
     /**
@@ -189,37 +212,9 @@ impl Subscription {
      */
 
     pub fn poll(&mut self, fragment_handler: &mut impl FnMut(&AtomicBuffer, Index, Index, &Header), fragment_limit: i32) -> i32 {
-        let image_list = self.image_list.load_mut();
-
-        let mut fragments_read = 0;
-
-        let mut starting_index = self.round_robin_index as usize;
-        self.round_robin_index += 1;
-
-        if starting_index >= image_list.len() {
-            self.round_robin_index = 0;
-            starting_index = 0;
-        }
-
-        for i in starting_index..image_list.len() {
-            if fragments_read < fragment_limit {
-                fragments_read += image_list
-                    .get_mut(i)
-                    .expect("Error getting element from Image vec")
-                    .poll(fragment_handler, fragment_limit - fragments_read);
-            }
-        }
-
-        for i in 0..starting_index {
-            if fragments_read < fragment_limit {
-                fragments_read += image_list
-                    .get_mut(i)
-                    .expect("Error getting element from Image vec")
-                    .poll(fragment_handler, fragment_limit - fragments_read);
-            }
-        }
-
-        fragments_read
+        self.poll_inner(fragment_limit, move |image, fragments_left| {
+            image.poll(fragment_handler, fragments_left)
+        })
     }
 
     /**
@@ -242,37 +237,9 @@ impl Subscription {
         fragment_handler: impl FnMut(&AtomicBuffer, Index, Index, &Header) -> Result<ControlledPollAction, AeronError> + Copy,
         fragment_limit: i32,
     ) -> i32 {
-        let image_list = self.image_list.load_mut();
-
-        let mut fragments_read = 0;
-
-        let mut starting_index = self.round_robin_index as usize;
-        self.round_robin_index += 1;
-
-        if starting_index >= image_list.len() {
-            self.round_robin_index = 0;
-            starting_index = 0;
-        }
-
-        for i in starting_index..image_list.len() {
-            if fragments_read < fragment_limit {
-                fragments_read += image_list
-                    .get_mut(i)
-                    .expect("Error getting element from Image vec")
-                    .controlled_poll(fragment_handler, fragment_limit - fragments_read);
-            }
-        }
-
-        for i in 0..starting_index {
-            if fragments_read < fragment_limit {
-                fragments_read += image_list
-                    .get_mut(i)
-                    .expect("Error getting element from Image vec")
-                    .controlled_poll(fragment_handler, fragment_limit - fragments_read);
-            }
-        }
-
-        fragments_read
+        self.poll_inner(fragment_limit, move |image, fragments_left| {
+            image.controlled_poll(fragment_handler, fragments_left)
+        })
     }
 
     /**

--- a/src/utils/bit_utils.rs
+++ b/src/utils/bit_utils.rs
@@ -26,18 +26,7 @@ pub fn is_power_of_two(value: Index) -> bool {
 
 /// Returns number of trailing bits which are set to 0
 pub fn number_of_trailing_zeroes(value: i32) -> i32 {
-    let table = [
-        0, 1, 2, 24, 3, 19, 6, 25, 22, 4, 20, 10, 16, 7, 12, 26, 31, 23, 18, 5, 21, 9, 15, 11, 30, 17, 8, 14, 29, 13, 28, 27,
-    ];
-
-    if value == 0 {
-        return 32;
-    }
-
-    // Use i64 inside the calculation to handle numbers close to i32::MAX without multiplication overflow
-    let index = ((value as i64 & -value as i64) * 0x04D7_651F) as u32;
-
-    table[(index >> 27) as usize]
+    value.trailing_zeros() as i32
 }
 
 pub fn find_next_power_of_two_i64(mut value: i64) -> i64 {
@@ -61,22 +50,6 @@ pub fn find_next_power_of_two_i64(mut value: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_number_of_trailing_zeroes() {
-        assert_eq!(number_of_trailing_zeroes(0), 32);
-        assert_eq!(number_of_trailing_zeroes(1), 0);
-        assert_eq!(number_of_trailing_zeroes(2), 1);
-        assert_eq!(number_of_trailing_zeroes(3), 0);
-        assert_eq!(number_of_trailing_zeroes(4), 2);
-        assert_eq!(number_of_trailing_zeroes(5), 0);
-        assert_eq!(number_of_trailing_zeroes(6), 1);
-        assert_eq!(number_of_trailing_zeroes(7), 0);
-        assert_eq!(number_of_trailing_zeroes(512), 9);
-        assert_eq!(number_of_trailing_zeroes(513), 0);
-        assert_eq!(number_of_trailing_zeroes(1_073_741_824), 30);
-        assert_eq!(number_of_trailing_zeroes(1_073_741_825), 0);
-    }
 
     #[test]
     fn test_next_power_of_two() {

--- a/src/utils/log_buffers.rs
+++ b/src/utils/log_buffers.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -83,12 +84,7 @@ impl LogBuffers {
 
         Ok(Self {
             memory_mapped_file: Some(memory_mapped_file),
-            buffers: [
-                *buffers.get(0).expect("Log buffers get(0) failed"),
-                *buffers.get(1).expect("Log buffers get(1) failed"),
-                *buffers.get(2).expect("Log buffers get(2) failed"),
-                *buffers.get(3).expect("Log buffers get(3) failed"),
-            ],
+            buffers: buffers.try_into().unwrap(),
         })
     }
 

--- a/src/utils/memory_mapped_file.rs
+++ b/src/utils/memory_mapped_file.rs
@@ -149,7 +149,8 @@ mod tests {
 
     #[test]
     fn test_creating_file() {
-        MemoryMappedFile::create_new(Path::new("abc.file"), 0, 128).unwrap();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        MemoryMappedFile::create_new(tmp_dir.path().join("abc.file"), 0, 128).unwrap();
     }
 
     #[allow(dead_code)]

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -42,11 +42,8 @@ pub fn unix_time_ns() -> Moment {
 
 /// Accepts Aeron style ASCII string (without zero termination). Outputs Rust String.
 pub unsafe fn aeron_str_to_rust(raw_str: *const u8, length: i32) -> String {
-    let str_slice = std::slice::from_raw_parts(raw_str, length as usize);
-    let mut zero_terminated: Vec<u8> = Vec::with_capacity(length as usize + 1);
-    zero_terminated.extend_from_slice(str_slice);
-
-    String::from_utf8_unchecked(zero_terminated)
+    let slice = std::slice::from_raw_parts(raw_str, length as usize);
+    std::str::from_utf8_unchecked(slice).to_owned()
 }
 
 pub fn semantic_version_compose(major: i32, minor: i32, patch: i32) -> i32 {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -24,14 +24,14 @@ pub mod types;
 
 #[macro_export]
 macro_rules! ttrace {
-        ($log_message:expr) => {
+        ($log_message:literal) => {
             if let Some(name) = std::thread::current().name() {
                 log::trace!("({}) {}", name, $log_message);
             } else {
                 log::trace!(concat!("(NoName) ", $log_message));
             }
         };
-        ($log_message:expr, $($args:tt)*) => {
+        ($log_message:literal, $($args:tt)*) => {
             if let Some(name) = std::thread::current().name() {
                 log::trace!(concat!("({}) ", $log_message), name, $($args)*);
             } else {


### PR DESCRIPTION
No semantic should be made there, if found it's an error.

Some other hints to improve the code:

- split up the god-types (i.e. the ones with >5 fields), in particular testing would be much easier;
- there's a lot of duplicated code, making it polymorphic might significantly reduce codebase size;
- use [derive_builder](https://crates.io/crates/derive_builder) for builders;
- use either [anyhow](https://crates.io/crates/anyhow) with thiserror, or even better use [snafu](https://crates.io/crates/snafu) instead for error handling.