### PR TITLE
Fix memory safety and ARM64 compatibility issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2021"
 
 [dependencies]
 thiserror = "2.0"
-cache_line_size="1.0"
 num-traits="0.2"
 lazy_static = "1.5"
 memmap = "0.7"

--- a/src/utils/memory_mapped_file.rs
+++ b/src/utils/memory_mapped_file.rs
@@ -136,7 +136,19 @@ impl MemoryMappedFile {
     }
 
     pub fn atomic_buffer(&self, offset: Index, size: Index) -> AtomicBuffer {
+        self.bounds_check(offset, size);
         unsafe { AtomicBuffer::new(self.ptr.offset(offset as isize), size) }
+    }
+
+    #[inline]
+    fn bounds_check(&self, offset: Index, size: Index) {
+        assert!(
+            offset >= 0 && size >= 0 && offset.saturating_add(size) <= self.memory_size,
+            "MemoryMappedFile bounds check failed: offset={}, size={}, memory_size={}",
+            offset,
+            size,
+            self.memory_size
+        );
     }
 }
 
@@ -210,5 +222,50 @@ mod tests {
             let option = *b.get(n).unwrap();
             assert_eq!(option, (n & 0xff) as u8)
         }
+    }
+
+    #[test]
+    fn test_atomic_buffer_within_bounds() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file_path = tmp_dir.path().join("bounds_test.file");
+        let file = MemoryMappedFile::create_new(file_path, 0, 128).unwrap();
+
+        // This should succeed - within bounds
+        let _buffer = file.atomic_buffer(0, 64);
+        let _buffer = file.atomic_buffer(64, 64);
+        let _buffer = file.atomic_buffer(0, 128);
+    }
+
+    #[test]
+    #[should_panic(expected = "bounds check failed")]
+    fn test_atomic_buffer_offset_out_of_bounds() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file_path = tmp_dir.path().join("bounds_test.file");
+        let file = MemoryMappedFile::create_new(file_path, 0, 128).unwrap();
+
+        // This should panic - offset way beyond file size
+        let _buffer = file.atomic_buffer(1_000_000, 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "bounds check failed")]
+    fn test_atomic_buffer_size_out_of_bounds() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file_path = tmp_dir.path().join("bounds_test.file");
+        let file = MemoryMappedFile::create_new(file_path, 0, 128).unwrap();
+
+        // This should panic - size exceeds file size
+        let _buffer = file.atomic_buffer(0, 256);
+    }
+
+    #[test]
+    #[should_panic(expected = "bounds check failed")]
+    fn test_atomic_buffer_offset_plus_size_overflow() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let file_path = tmp_dir.path().join("bounds_test.file");
+        let file = MemoryMappedFile::create_new(file_path, 0, 128).unwrap();
+
+        // This should panic - offset + size exceeds file size
+        let _buffer = file.atomic_buffer(100, 100);
     }
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -17,11 +17,17 @@
 use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cache_line_size::CACHE_LINE_SIZE;
-
 use crate::utils::types::{Index, Moment};
 
-pub const CACHE_LINE_LENGTH: Index = CACHE_LINE_SIZE as Index;
+/// Cache line length used for padding and alignment in Aeron protocol structures.
+///
+/// This is set to 64 bytes to match the Aeron protocol specification and ensure
+/// compatibility with the Aeron media driver. While some architectures (like ARM64)
+/// may have 128-byte cache lines, the protocol requires 64-byte alignment for
+/// interoperability.
+///
+/// See: https://github.com/UnitedTraders/aeron-rs/issues/29
+pub const CACHE_LINE_LENGTH: Index = 64;
 
 #[inline]
 /// Get system time since start of UNIX epoch in milliseconds (ms) (10^-3 sec)
@@ -71,15 +77,15 @@ pub fn semantic_version_to_string(version: i32) -> String {
     )
 }
 
-/// Allocate a buffer aligned on the cache size
+/// Allocate a buffer aligned on the cache line size
 pub fn alloc_buffer_aligned(size: Index) -> *mut u8 {
     unsafe {
-        let layout = Layout::from_size_align_unchecked(size as usize, CACHE_LINE_SIZE);
+        let layout = Layout::from_size_align_unchecked(size as usize, CACHE_LINE_LENGTH as usize);
         alloc_zeroed(layout)
     }
 }
 
-/// Deallocate a buffer aligned on a cache size
+/// Deallocate a buffer aligned on a cache line size
 pub unsafe fn dealloc_buffer_aligned(buff_ptr: *mut u8, len: Index) {
     if cfg!(debug_assertions) {
         // dealloc markers for debug
@@ -88,7 +94,7 @@ pub unsafe fn dealloc_buffer_aligned(buff_ptr: *mut u8, len: Index) {
         }
     }
 
-    let layout = Layout::from_size_align_unchecked(len as usize, CACHE_LINE_SIZE);
+    let layout = Layout::from_size_align_unchecked(len as usize, CACHE_LINE_LENGTH as usize);
     dealloc(buff_ptr, layout)
 }
 


### PR DESCRIPTION
Fixes #31: Add bounds checking to MemoryMappedFile::atomic_buffer()
- Validates offset and size before creating AtomicBuffer
- Prevents out-of-bounds memory access with invalid parameters
- Added tests for bounds checking

Fixes #29: Fix CACHE_LINE_LENGTH for ARM64 compatibility
- Use fixed 64-byte cache line length matching Aeron protocol spec
- Removes cache_line_size dependency that returned incorrect values on ARM64
- Ensures ring buffer capacity calculations work correctly on all platforms